### PR TITLE
feat: reenable some prettier config disabled rules

### DIFF
--- a/plugins/prettier.js
+++ b/plugins/prettier.js
@@ -6,5 +6,13 @@ module.exports = {
 
   rules: {
     'prettier/prettier': 'error',
+
+    // https://github.com/prettier/eslint-config-prettier#curly
+    // prettier doesn't enforce {} with multiline
+    curly: ['error', 'multi-line'],
+
+    // https://github.com/prettier/eslint-config-prettier#quotes
+    // prettier doesn't change backtick to single
+    quotes: ['error', 'single', { avoidEscape: true }],
   },
 };


### PR DESCRIPTION
BREAKING CHANGE: rules `curly` and `quotes` reenabled