### PR TITLE
feat: enable react jsx sort props

### DIFF
--- a/rules/react.js
+++ b/rules/react.js
@@ -8,6 +8,16 @@ module.exports = {
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-direct-mutation-state.md
     'react/no-direct-mutation-state': 'error',
 
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-props.md
+    'react/jsx-sort-props': [
+      'error',
+      {
+        reservedFirst: true,
+        shorthandFirst: true,
+        callbacksLast: true,
+      },
+    ],
+
     /* changed rules */
 
     // https://github.com/yannickcr/eslint-plugin-react/blob/843d71a432baf0f01f598d7cf1eea75ad6896e4b/docs/rules/sort-comp.md


### PR DESCRIPTION
BREAKING CHANGE: new rule enabled: react/jsx-sort-props